### PR TITLE
[WIP] Bring FancyTree into the TreeBrowserBundle

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,3 +1,3 @@
 {
-    "directory": "Resources/public/js/vendor"
+    "directory": "Resources/public/vendor"
 }

--- a/.bowerrc
+++ b/.bowerrc
@@ -1,0 +1,3 @@
+{
+    "directory": "Resources/public/js/vendor"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-vendor
+/vendor/
 composer.lock
 composer.phar
 Tests/Resources/app/cache

--- a/Resources/public/css/fontawesome-style.css
+++ b/Resources/public/css/fontawesome-style.css
@@ -1,0 +1,68 @@
+ul.fancytree-container {
+    font-family: 'Source Sans Pro', sans-serif;
+    font-size: 14px;
+    border: none;
+}
+ul.fancytree-container:focus {
+    outline:none;
+}
+.fancytree-loading span.fancytree-expander,
+.fancytree-loading span.fancytree-expander:hover {
+    background: initial;
+}
+
+.fancytree-loading span.fancytree-expander:before,
+.fancytree-loading span.fancytree-expander:hover:before,
+.fancytree-statusnode-wait span.fancytree-icon:before,
+.fancytree-statusnode-wait span.fancytree-icon:hover:before{
+    font-family: FontAwesome;
+    content: ' \f110';
+    -webkit-animation: fa-spin 2s infinite linear;
+    animation: fa-spin 2s infinite linear;
+}
+@-webkit-keyframes fa-spin {
+  0% {
+    -webkit-transform: rotate(0deg);
+    transform: rotate(0deg);
+  }
+  100% {
+    -webkit-transform: rotate(359deg);
+    transform: rotate(359deg);
+  }
+}
+@keyframes fa-spin {
+  0% {
+    -webkit-transform: rotate(0deg);
+    transform: rotate(0deg);
+  }
+  100% {
+    -webkit-transform: rotate(359deg);
+    transform: rotate(359deg);
+  }
+}
+
+.fancytree-container .fancytree-icon {
+    background: initial !important;
+}
+.fancytree-container .fancytree-icon:before {
+    display: inline-block;
+    font-family: FontAwesome;
+    font-style: normal;
+    font-weight: normal;
+    font-size: 14px;
+    line-height: 1;
+    color: #333;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+}
+.fancytree-node .fancytree-icon:before {
+    content: " \f016"; /* fa-file-o */
+}
+.fancytree-expanded .fancytree-icon:before,
+.fancytree-folder .fancytree-icon:before {
+    content: " \f07b"; /* fa-folder */
+}
+
+.fancytree-statusnode-wait .fancytree-icon:before {
+    content: "";
+}

--- a/Resources/public/js/adapter/fancytree.js
+++ b/Resources/public/js/adapter/fancytree.js
@@ -71,6 +71,11 @@ var FancytreeAdapter = function (dataUrl) {
 
                             data.result.push(sourceNode);
                         });
+
+                        // if there is one root node, expand it
+                        if (1 == data.result.length) {
+                            data.result[0].expanded = true;
+                        }
                     } else {
                         data.result = {
                             // todo: maybe use a more admin friendly error message in prod?

--- a/Resources/public/js/adapter/fancytree.js
+++ b/Resources/public/js/adapter/fancytree.js
@@ -92,15 +92,23 @@ var FancytreeAdapter = function (dataUrl) {
                 $input.val(data.node.getKeyPath());
             });
 
-            // change active node when the value of the input field changed
-            var tree = this.tree;
-            $input.on('change', function (e) {
-                tree.loadKeyPath($(this).val(), function (node, status) {
+            var showKey = function (key) {
+                tree.loadKeyPath(key, function (node, status) {
                     if ('ok' == status) {
                         node.setExpanded();
                         node.setActive();
                     }
                 });
+            };
+
+            // use initial input value as active node
+            $tree.bind('fancytreeinit', function (event, data) {
+                showKey($input.val());
+            });
+
+            // change active node when the value of the input field changed
+            $input.on('change', function (e) {
+                showKey($(this).val());
             });
         }
     };

--- a/Resources/public/js/adapter/fancytree.js
+++ b/Resources/public/js/adapter/fancytree.js
@@ -4,7 +4,7 @@
  * @author Wouter J <wouter@wouterj.nl>
  * @see https://github.com/mar10/fancytree
  */
-var FancytreeAdapter = function (data_url) {
+var FancytreeAdapter = function (dataUrl) {
     if (!window.jQuery || !jQuery.fn.fancytree) {
         throw 'The FancytreeAdapter requires both jQuery and the FancyTree library.';
     }
@@ -28,21 +28,20 @@ var FancytreeAdapter = function (data_url) {
 
         return fancytreeNode;
     };
+    // FancyTree instance
+    var tree;
+    // jQuery instance of the tree output element
+    var $tree;
 
     return {
-        tree: null,
-        $elem: null,
-        data_url: data_url,
-
         bindToElement: function ($elem) {
             if (!$elem instanceof jQuery) {
                 throw  'FancytreeAdapter can only be adapted to a jQuery object.';
             }
 
-            this.$elem = $elem;
-            var dataUrl = this.data_url;
+            $tree = $elem;
 
-            $elem.fancytree({
+            $tree.fancytree({
                 // the start data (root node + children)
                 source: { url: dataUrl },
 
@@ -84,12 +83,12 @@ var FancytreeAdapter = function (data_url) {
                 activeVisible: true
             });
 
-            this.tree = $elem.fancytree('getTree');
+            tree = $tree.fancytree('getTree');
         },
 
         bindToInput: function ($input) {
             // output active node to input field
-            this.$elem.fancytree('option', 'activate', function(event, data) {
+            $tree.fancytree('option', 'activate', function(event, data) {
                 $input.val(data.node.getKeyPath());
             });
 

--- a/Resources/public/js/adapter/fancytree.js
+++ b/Resources/public/js/adapter/fancytree.js
@@ -1,0 +1,108 @@
+/**
+ * A tree browser adapter for the Fancytree library.
+ *
+ * @author Wouter J <wouter@wouterj.nl>
+ * @see https://github.com/mar10/fancytree
+ */
+var FancytreeAdapter = function (data_url) {
+    if (!window.jQuery || !jQuery.fn.fancytree) {
+        throw 'The FancytreeAdapter requires both jQuery and the FancyTree library.';
+    }
+
+    var requestNodeToFancytreeNode = function (requestNode) {
+        var fancytreeNode = {
+            // fixme: remove ugly replacing by just not putting stuff like this in the JSON response
+            title: requestNode.data.replace(' (not editable)', ''),
+            // fixme: also put the current node name in the JSON response, not just the complete path
+            key: requestNode.attr.id.match(/\/([^\/]+)$/)[1]
+        };
+        
+        // fixme: have more descriptive JSON keys to determine if it has children
+        if (null != requestNode.state) {
+            fancytreeNode.folder = true;
+        }
+
+        if ('closed' == requestNode.state) {
+            fancytreeNode.lazy = true;
+        }
+
+        return fancytreeNode;
+    };
+
+    return {
+        tree: null,
+        $elem: null,
+        data_url: data_url,
+
+        bindToElement: function ($elem) {
+            if (!$elem instanceof jQuery) {
+                throw  'FancytreeAdapter can only be adapted to a jQuery object.';
+            }
+
+            this.$elem = $elem;
+            var dataUrl = this.data_url;
+
+            $elem.fancytree({
+                // the start data (root node + children)
+                source: { url: dataUrl },
+
+                // lazy load the children when a node is collapsed
+                lazyLoad: function (event, data) {
+                    data.result = {
+                        url: dataUrl,
+                        data: { root: data.node.getKeyPath() }
+                    };
+                },
+
+                // transform the JSON response into a data structure that's supported by FancyTree
+                postProcess: function (event, data) {
+                    if (null == data.error) {
+                        data.result = []
+
+                        data.response.forEach(function (node) {
+                            var sourceNode = requestNodeToFancytreeNode(node);
+
+                            if (node.children) {
+                                sourceNode.children = [];
+
+                                node.children.forEach(function (leaf) {
+                                    sourceNode.children.push(requestNodeToFancytreeNode(leaf));
+                                });
+                            }
+
+                            data.result.push(sourceNode);
+                        });
+                    } else {
+                        data.result = {
+                            // todo: maybe use a more admin friendly error message in prod?
+                            error: 'An error occured while retrieving the nodes: ' + data.error
+                        };
+                    }
+                },
+
+                // always show the active node
+                activeVisible: true
+            });
+
+            this.tree = $elem.fancytree('getTree');
+        },
+
+        bindToInput: function ($input) {
+            // output active node to input field
+            this.$elem.fancytree('option', 'activate', function(event, data) {
+                $input.val(data.node.getKeyPath());
+            });
+
+            // change active node when the value of the input field changed
+            var tree = this.tree;
+            $input.on('change', function (e) {
+                tree.loadKeyPath($(this).val(), function (node, status) {
+                    if ('ok' == status) {
+                        node.setExpanded();
+                        node.setActive();
+                    }
+                });
+            });
+        }
+    };
+};

--- a/Resources/public/js/jquery.cmf_tree.js
+++ b/Resources/public/js/jquery.cmf_tree.js
@@ -1,0 +1,42 @@
+/**
+ * A simple layer between the jQuery front-end and the JS tree library used.
+ *
+ * By default, it uses the FancytreeAdapter. You can pass other adapters by
+ * changing the `adapter` setting.
+ *
+ * @author Wouter J <wouter@wouterj.nl>
+ */
+jQuery.fn.cmfTree = function (options) {
+    options = jQuery.extend({
+        adapter: null,
+    }, options);
+
+    // configure options
+    var $treeOutput = $(this);
+    var selectElement = function (selector) {
+        if ('string' == typeof(selector)) {
+            return $(selector);
+        } else if (selector instanceof jQuery) {
+            return selector;
+        }
+
+        throw 'Cannot handle selector ' + selector + '. You may want to pass a jQuery object or a jQuery selector.';
+    };
+
+    if (!options.data_url) {
+        throw 'cmfTree needs an AJAX URL to lazy load the tree, pass it using the `data_url` option.';
+    }
+
+    if (!options.adapter) {
+        options.adapter = new FancytreeAdapter(options.data_url);
+    }
+    var adapter = options.adapter;
+
+    // render tree
+    adapter.bindToElement($treeOutput);
+
+    // optionally bind the tree to an input element
+    if (options.path_output) {
+        adapter.bindToInput(selectElement(options.path_output));
+    }
+};

--- a/Resources/views/Base/tree.html.twig
+++ b/Resources/views/Base/tree.html.twig
@@ -1,11 +1,11 @@
 <script type="text/javascript" src="{{ asset('bundles/fosjsrouting/js/router.js') }}"></script>
 <script type="text/javascript" src="{{ path('fos_js_routing_js', {"callback": "fos.Router.setData"}) }}"></script>
 
-<script>window.jQuery || document.write(unescape('%3Cscript src="{{ asset('bundles/cmf/treebrowser/js/vendor/jquery/dist/jquery.min.js') }}"%3E%3C/script%3E'))</script>
-<script>jQuery.ui || document.write(unescape('%3Cscript src="{{ asset('bundles/cmf/treebrowser/js/vendor/jquery-ui/jquery-ui.min.js') }}"%3E%3C/script%3E'))</script>
-<script src="{{ asset('bundles/cmftreebrowser/js/vendor/fancytree/dist/jquery.fancytree-all.min.js') }}" type="text/javascript"></script>
+<script>window.jQuery || document.write(unescape('%3Cscript src="{{ asset('bundles/cmftreebrowser/vendor/jquery/dist/jquery.min.js') }}"%3E%3C/script%3E'))</script>
+<script>jQuery.ui || document.write(unescape('%3Cscript src="{{ asset('bundles/cmftreebrowser/vendor/jquery-ui/jquery-ui.min.js') }}"%3E%3C/script%3E'))</script>
+<script src="{{ asset('bundles/cmftreebrowser/vendor/fancytree/dist/jquery.fancytree-all.min.js') }}" type="text/javascript"></script>
 <script src="{{ asset('bundles/cmftreebrowser/js/adapter/fancytree.js') }}"></script>
 <script src="{{ asset('bundles/cmftreebrowser/js/jquery.cmf_tree.js') }}"></script>
 
-<link rel="stylesheet" href="{{ asset('vendor/fancytree/dist/skin-win8/ui.fancytree.min.css') }}" type="text/css" media="all"/>
+<link rel="stylesheet" href="{{ asset('bundles/cmftreebrowser/vendor/fancytree/dist/skin-win8/ui.fancytree.min.css') }}" media="all"/>
 <link rel="stylesheet" href="{{ asset('bundles/cmftreebrowser/css/fontawesome-style.css') }}" media="all"/>

--- a/Resources/views/Base/tree.html.twig
+++ b/Resources/views/Base/tree.html.twig
@@ -8,3 +8,4 @@
 <script src="{{ asset('bundles/cmftreebrowser/js/jquery.cmf_tree.js') }}"></script>
 
 <link rel="stylesheet" href="{{ asset('vendor/fancytree/dist/skin-win8/ui.fancytree.min.css') }}" type="text/css" media="all"/>
+<link rel="stylesheet" href="{{ asset('bundles/cmftreebrowser/css/fontawesome-style.css') }}" media="all"/>

--- a/Resources/views/Base/tree.html.twig
+++ b/Resources/views/Base/tree.html.twig
@@ -1,10 +1,8 @@
 <script type="text/javascript" src="{{ asset('bundles/fosjsrouting/js/router.js') }}"></script>
 <script type="text/javascript" src="{{ path('fos_js_routing_js', {"callback": "fos.Router.setData"}) }}"></script>
 
-<script src="{{ asset('bundles/cmftreebrowser/js/jquery.jstree.js') }}" type="text/javascript"></script>
-<script src="{{ asset('bundles/cmftreebrowser/js/jquery.cookie.js') }}" type="text/javascript"></script>
+<script src="{{ asset('bundles/cmftreebrowser/js/vendor/fancytree/dist/jquery.fancytree-all.min.js') }}" type="text/javascript"></script>
+<script src="{{ asset('bundles/cmftreebrowser/js/adapter/fancytree.js') }}"></script>
+<script src="{{ asset('bundles/cmftreebrowser/js/jquery.cmf_tree.js') }}"></script>
 
-<script src="{{ asset('bundles/cmftreebrowser/js/admin_tree.js') }}" type="text/javascript"></script>
-<script src="{{ asset('bundles/cmftreebrowser/js/select_tree.js') }}" type="text/javascript"></script>
-
-<link rel="stylesheet" href="{{ asset('bundles/cmftreebrowser/css/style.css') }}" type="text/css" media="all"/>
+<link rel="stylesheet" href="{{ asset('vendor/fancytree/dist/skin-win8/ui.fancytree.min.css') }}" type="text/css" media="all"/>

--- a/Resources/views/Base/tree.html.twig
+++ b/Resources/views/Base/tree.html.twig
@@ -1,6 +1,8 @@
 <script type="text/javascript" src="{{ asset('bundles/fosjsrouting/js/router.js') }}"></script>
 <script type="text/javascript" src="{{ path('fos_js_routing_js', {"callback": "fos.Router.setData"}) }}"></script>
 
+<script>window.jQuery || document.write(unescape('%3Cscript src="{{ asset('bundles/cmf/treebrowser/js/vendor/jquery/dist/jquery.min.js') }}"%3E%3C/script%3E'))</script>
+<script>jQuery.ui || document.write(unescape('%3Cscript src="{{ asset('bundles/cmf/treebrowser/js/vendor/jquery-ui/jquery-ui.min.js') }}"%3E%3C/script%3E'))</script>
 <script src="{{ asset('bundles/cmftreebrowser/js/vendor/fancytree/dist/jquery.fancytree-all.min.js') }}" type="text/javascript"></script>
 <script src="{{ asset('bundles/cmftreebrowser/js/adapter/fancytree.js') }}"></script>
 <script src="{{ asset('bundles/cmftreebrowser/js/jquery.cmf_tree.js') }}"></script>

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,17 @@
+{
+    "name": "symfony-cmf-tree-browser-bundle",
+    "homepage": "http://cmf.symfony.com",
+    "keywords": ["Symfony CMF", "tree", "phpcr"],
+    "authors": [
+        {
+            "name": "Symfony CMF Community",
+            "homepage": "https://github.com/symfony-cmf/TreeBrowserBundle/contributors"
+        }
+    ],
+    "license": "MIT",
+    "dependencies": {
+        "fancytree": "2.7.*"
+    },
+    "private": true,
+    "ignore": ["*"]
+}

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.1-dev"
+            "dev-master": "2.0-dev"
         }
     }
 }


### PR DESCRIPTION
My first shot in using FancyTree for the TreeBrowserBundle and making it easy to add other implementations.

What's done?
---

**Bower is used to require fancytree**

We can install the packages by default, this means people don't have to use bower. I've not done included that in this PR, to make it easier to review.

**Refactor to a jQuery cmfTree plugin**

Instead of SelectTree and AdminTree objects, I've choosen to create a cmfTree plugin. This will work both as the select and admin tree. This means the usage is now very easy:

````javascript
$('#tree-selector').cmfTree({
    data_url: '_cmf_tree_children...'
});
````

**Use adapters to allow other tree implementations**

The plugin is just a very simple wrapper around adapters. The adapters contain to logic to make the features work with different tree implementations. Currently, only a `FancytreeAdapter` is provided and this is also the default. You can pass other adapters:

````javascript
$('#tree-selector').cmfTree({
    // ...
    adapter: new JsTreeAdapter()
});
````

**Binding to input field works in 2 directions**

Previously, the input field was disabled and could only be updated by using the tree. The FancyTree adapter now supports both directions: When selecting a node in the tree, the input field is updated with the path and when typing a path in the input field, the tree selects to corresponding node. Input binding is pretty easy:

````javascript
$('#tree-selector').cmfTree({
    // ...
    path_output: '#tree-selector-path-output'
});
````

Future PRs will move the tree thing to a pop-up box, as it currently takes way to much space for something no that important imo. Another PR will also support path autocompletion when typing in the input field.

Things to do
---

* [ ] Implement admin tree
* [ ] Remove all references to the old tree lib and old objects
* [ ] Update SonataDoctrinePhpcrAdminBundle
* [ ] Update documentation

Things to do in the future
---

* Update to use ResourceRestBundle. There currently are some `fixme` comments in the code, this is all due to very strange JSON response of the TreeBrowserBundle. This will be solved once we use ResourceRestBundle as back-end bundle for this.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | not yet
| Fixed tickets | #73, #66, https://github.com/sonata-project/SonataDoctrinePhpcrAdminBundle/issues/207, https://github.com/sonata-project/SonataDoctrinePhpcrAdminBundle/issues/148
| License       | MIT
| Doc PR        | todo

/cc @dantleech @lsmith77 @dbu