### PR TITLE
Added contextmenu with custom actions

### DIFF
--- a/Resources/public/js/adapter/fancytree.js
+++ b/Resources/public/js/adapter/fancytree.js
@@ -10,6 +10,10 @@ var FancytreeAdapter = function (requestData) {
     }
 
     var requestNodeToFancytreeNode = function (requestNode) {
+        if (requestNode.length === 0) {
+            return;
+        }
+
         var title = requestNode.path.substr(requestNode.path.lastIndexOf('/') + 1) || '/';
         var fancytreeNode = {
             // fixme: use sonata enhancer to get node name based on Admin#toString
@@ -19,15 +23,20 @@ var FancytreeAdapter = function (requestData) {
             children: []
         };
 
+        var childrenCount = 0;
         for (name in requestNode.children) {
             if (!requestNode.children.hasOwnProperty(name)) {
                 continue;
             }
 
-            fancytreeNode.children.push(requestNodeToFancytreeNode(requestNode.children[name]));
+            var child = requestNodeToFancytreeNode(requestNode.children[name]);
+            if (child) {
+                fancytreeNode.children.push(child);
+            }
+            childrenCount++;
         }
 
-        if (fancytreeNode.children.length) {
+        if (childrenCount) {
             fancytreeNode.folder = true;
             fancytreeNode.lazy = true;
         }
@@ -53,7 +62,7 @@ var FancytreeAdapter = function (requestData) {
 
                 // lazy load the children when a node is collapsed
                 lazyLoad: function (event, data) {
-                    data.result = jQuery.merge({
+                    data.result = jQuery.extend({
                         data: {}
                     }, requestData.load(data.node.getKeyPath()));
                 },

--- a/Resources/public/js/adapter/fancytree.js
+++ b/Resources/public/js/adapter/fancytree.js
@@ -9,16 +9,35 @@ var FancytreeAdapter = function (requestData) {
         throw 'The FancytreeAdapter requires both jQuery and the FancyTree library.';
     }
 
+    var actions = {};
     var requestNodeToFancytreeNode = function (requestNode) {
         if (requestNode.length === 0) {
             return;
         }
 
         var fancytreeNode = {
-            title: requestNode.resource_label,
+            title: requestNode.label,
             key: requestNode.node_name,
-            children: []
+            children: [],
+            actions: {}
         };
+
+        for (actionName in actions) {
+            if (!actions.hasOwnProperty(actionName)) {
+                continue;
+            }
+
+            var action = actions[actionName];
+            var url = action.url;
+            if (typeof action.url == 'object' && action.url.hasOwnProperty('data')) {
+                url = getPropertyFromString(action.url.data, requestNode);
+            }
+
+            if (url === undefined) {
+                continue;
+            }
+            fancytreeNode['actions'][actionName] = { label: actionName, iconClass: action.icon, url: url };
+        }
 
         var childrenCount = 0;
         for (name in requestNode.children) {
@@ -83,6 +102,17 @@ var FancytreeAdapter = function (requestData) {
                 activeVisible: true
             });
 
+            if (actions) {
+                $tree.cmfContextMenu({
+                    delegate: 'span.fancytree-title',
+                    wrapperTemplate: '<ul class="dropdown-menu" style="display:block;"></ul>',
+                    actionTemplate: '<li role="presentation"><a role="menuitem" href="{{ url }}"><i class="{{ iconClass }}"></i> {{ label }}</li>',
+                    actions: function ($node) {
+                        return jQuery.ui.fancytree.getNode($node).data.actions;
+                    }
+                });
+            }
+
             tree = $tree.fancytree('getTree');
         },
 
@@ -110,6 +140,29 @@ var FancytreeAdapter = function (requestData) {
             $input.on('change', function (e) {
                 showKey($(this).val());
             });
+        },
+
+        addAction: function (name, url, icon) {
+            actions[name] = { url: url, icon: icon };
         }
     };
 };
+
+function getPropertyFromString(propertyPath, list) {
+    var isOptional = propertyPath.substr(0, 1) === '?';
+    var props = propertyPath.substr(1).split('.');
+    var currentNode = list;
+    for (prop in props) {
+        currentNode = currentNode[props[prop]];
+
+        if (undefined === currentNode) {
+            if (isOptional) {
+                break;
+            }
+
+            throw 'Attribute "' + props[prop] + '" does not exists';
+        }
+    }
+
+    return currentNode;
+}

--- a/Resources/public/js/adapter/fancytree.js
+++ b/Resources/public/js/adapter/fancytree.js
@@ -14,12 +14,9 @@ var FancytreeAdapter = function (requestData) {
             return;
         }
 
-        var title = requestNode.path.substr(requestNode.path.lastIndexOf('/') + 1) || '/';
         var fancytreeNode = {
-            // fixme: use sonata enhancer to get node name based on Admin#toString
-            title: title,
-            // fixme: also put the current node name in the JSON response, not just the complete path
-            key: title,
+            title: requestNode.resource_label,
+            key: requestNode.node_name,
             children: []
         };
 

--- a/Resources/public/js/jquery.cmf_context_menu.js
+++ b/Resources/public/js/jquery.cmf_context_menu.js
@@ -1,0 +1,131 @@
+/**
+ * A very flexible and simple jQuery context menu plugin.
+ *
+ * @author Wouter J <wouter@wouterj.nl>
+ */
+jQuery.fn.cmfContextMenu = function (options) {
+    options = jQuery.extend({
+        /**
+         * The selector used to delegate the contextmenu event too.
+         *
+         *     $('#tree').cmfContextMenu({ delegate: '.hasMenu' })
+         *
+         * Will delegate the contextmenu event to all `.hasMenu`
+         * childs in `#tree`.
+         *
+         * @var string|null
+         */
+        delegate: null,
+
+        /**
+         * A list of actions in the context menu or a callback.
+         *
+         * In case of a callback, it will be called with the target
+         * element. This means the action list can be build dynamically
+         * based on the target.
+         *
+         * The contextmenu will not be shown if this list is empty or if
+         * the callback returned `false`.
+         *
+         * @var object|function
+         */
+        actions: [],
+
+        /**
+         * A callback that's called when an action is selected.
+         *
+         * The callback will be provided with the element the contextmenu was
+         * bound to and the click event.
+         *
+         * @var function
+         */
+        select: function ($action, event) { },
+
+        /**
+         * The template to use for the wrapper element.
+         *
+         * @var string
+         */
+        wrapperTemplate: '<ul id="cmf-context-menu"></ul>',
+
+        /**
+         * The template to use for each action element.
+         *
+         * You can include vars with the `{{ varName }}` syntax. The available
+         * vars are the properties of the action object set in `actions`.
+         *
+         * @var string
+         */
+        actionTemplate: '<li><i class="{{ iconClass }}"></i> {{ label }}</li>'
+    }, options);
+
+    var $body = $('body');
+    var $menu;
+
+    // respond to right click
+    $(this).on('contextmenu', options.delegate, function (e) {
+        e.preventDefault();
+
+        var $target = $(this);
+
+        // remove already shown menu
+        $menu && $menu.remove();
+
+        // generate actions
+        var actions = options.actions;
+        if (typeof actions === 'function') {
+            actions = actions($target);
+        }
+
+        if (false === actions || jQuery.isEmptyObject(actions)) {
+            return;
+        }
+
+        // generate the menu element
+        $menu = (function () {
+            var $wrapper = $(options.wrapperTemplate);
+            var $menu = $wrapper.is('ul') ? $wrapper : $wrapper.find('ul');
+            for (var cmd in actions) {
+                var action = actions[cmd];
+                var $action = $((function () {
+                    var tmp = options.actionTemplate;
+                    for (var prop in action) {
+                        if (!action.hasOwnProperty(prop)) {
+                            continue;
+                        }
+
+                        tmp = tmp.replace('{{ ' + prop + ' }}', action[prop]);
+                    }
+
+                    return tmp;
+                })());
+
+                $action.data('cmd', cmd);
+
+                $menu.append($action);
+            }
+
+            return $wrapper;
+        })();
+
+        // align it on the page
+        $menu.css({
+            top: e.pageY,
+            left: e.pageX
+        });
+
+        $body.append($menu);
+
+        // respond to a click on an action
+        $menu.on('click', 'li', function (e) {
+            e.stopPropagation();
+
+            options.select($target, e);
+        });
+    });
+
+    // when clicked anywhere outside of the contextmenu, hide the menu
+    $('html').on('click', function (e) {
+        $menu && $menu.remove();
+    });
+};

--- a/Resources/public/js/jquery.cmf_tree.js
+++ b/Resources/public/js/jquery.cmf_tree.js
@@ -11,7 +11,8 @@ jQuery.fn.cmfTree = function (options) {
         adapter: null,
         request: {
             load: null
-        }
+        },
+        actions: {}
     }, options);
 
     // configure options
@@ -37,6 +38,23 @@ jQuery.fn.cmfTree = function (options) {
     
     if (!adapter.bindToElement) {
         throw 'cmfTree adapters must have a bindToElement() method to specify the output element of the tree.';
+    }
+
+    for (actionName in options.actions) {
+        if (!options.actions.hasOwnProperty(actionName)) {
+            continue;
+        }
+
+        if (!adapter.addAction) {
+            throw 'The configured cmfTree adapter does not support actions, implement the addAction() method or use another adapter.';
+        }
+        var action = options.actions[actionName];
+
+        if (!action.url) {
+            throw 'actions should have a url defined, "' + actionName + '" does not.';
+        }
+
+        adapter.addAction(actionName, action.url, action.icon);
     }
 
     // render tree

--- a/Resources/views/Base/scripts.html.twig
+++ b/Resources/views/Base/scripts.html.twig
@@ -9,6 +9,7 @@
 {% endif %}
 
 <script src="{{ asset('bundles/cmftreebrowser/js/adapter/' ~ treeAdapter ~ '.js') }}"></script>
+<script src="{{ asset('bundles/cmftreebrowser/js/jquery.cmf_context_menu.js') }}"></script>
 <script src="{{ asset('bundles/cmftreebrowser/js/jquery.cmf_tree.js') }}"></script>
 
 <link rel="stylesheet" href="{{ asset(assetsBasePath ~ '/fancytree/dist/skin-win8/ui.fancytree.min.css') }}" media="all"/>


### PR DESCRIPTION
This PR adds a context menu with custom actions to the tree. I've decided to create a simple custom context menu plugin, as others either didn't support event delegation or didn't have an easy way to tweak the styling (with the admin becoming increasingly beautifull, we have to pay attention to CMF styles :smiley:).

In short, this PR adds a `cmfContextMenu` jQuery plugin and an `actions` setting for the `cmfTree` plugin.

Screenshot:
![cmf-tree-context-menu](https://cloud.githubusercontent.com/assets/749025/7316840/c92cbc5c-ea7a-11e4-8905-3d209ddac9dd.png)

Fixes #80
An implementation can be found in: https://github.com/sonata-project/SonataDoctrinePhpcrAdminBundle/pull/336
This PR requires: https://github.com/symfony-cmf/ResourceRestBundle/pull/12, https://github.com/symfony-cmf/ResourceRestBundle/pull/13